### PR TITLE
Improve startup and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+KRAKEN_API_KEY=your_kraken_api_key
+KRAKEN_API_SECRET=your_kraken_api_secret
+DATABASE_URL=postgresql://willow_user:securepassword@localhost/willow_db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Willow
+
+A simple Kraken crypto trading bot.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Copy `.env.example` to `.env` and fill in your credentials:
+   ```bash
+   cp .env.example .env
+   ```
+   Edit `.env` to provide your `KRAKEN_API_KEY`, `KRAKEN_API_SECRET`, and database URL.
+
+3. Initialize the database tables:
+   ```bash
+   python init_db.py
+   ```
+
+4. Run the bot:
+   ```bash
+   python main.py
+   ```

--- a/db.py
+++ b/db.py
@@ -1,8 +1,15 @@
+import os
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
-DATABASE_URL = "postgresql://willow_user:securepassword@localhost/willow_db"
+load_dotenv()
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://willow_user:securepassword@localhost/willow_db",
+)
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/indicators.py
+++ b/indicators.py
@@ -70,7 +70,7 @@ class Indicators:
             score += 20
         if 30 < indicators['RSI'] < 70:
             score += 20
-        if indicators['close'] < indicators['close'] * 0.995:
+        if indicators['close'] < indicators['EMA_9'] * 0.995:
             score += 20
         if indicators['OBV'] > 0:
             score += 20

--- a/main.py
+++ b/main.py
@@ -14,3 +14,7 @@ async def main():
         client.stream_private()
     )
 
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pandas
+pandas-ta
+requests
+websockets
+python-dotenv
+sqlalchemy
+psycopg2-binary
+rich
+pycoingecko


### PR DESCRIPTION
## Summary
- add run block in `main.py`
- fix scoring logic in `indicators`
- load database URL from `.env`
- document setup instructions
- include example `.env` and Python requirements

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68696661e2448329b041af274dfc375f